### PR TITLE
Fix UI import casing

### DIFF
--- a/frontend/src/components/tabs/RealDialogsTab.jsx
+++ b/frontend/src/components/tabs/RealDialogsTab.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import '@/components/tabs/RealDialogsTab.css';
-import { Input } from '@/components/ui/input';
+import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';

--- a/frontend/src/components/ui/index.js
+++ b/frontend/src/components/ui/index.js
@@ -1,8 +1,8 @@
-export { default as Button } from './Button';
-export { default as Input } from './Input';
-export { default as Textarea } from './Textarea';
-export { default as Select } from './Select';
-export { default as Label } from './Label';
-export { default as Dialog } from './Dialog';
-export { default as Badge } from './Badge';
-export { default as Switch } from './Switch';
+export { Button } from './button';
+export { Input } from './Input';
+export { Textarea } from './textarea';
+export { Select } from './select';
+export { Label } from './label';
+export { Dialog } from './dialog';
+export { Badge } from './badge';
+export { Switch } from './switch';


### PR DESCRIPTION
## Summary
- fix case mismatch for Input component path
- correct non-default exports in `ui/index.js`

## Testing
- `npm run dev` (frontend)
- `uvicorn backend.main:app --port 8000 --reload`

------
https://chatgpt.com/codex/tasks/task_e_68850c65fd4483298df485601b248681